### PR TITLE
Add reading of plug programs.

### DIFF
--- a/pySmartPlugSmpB16.py
+++ b/pySmartPlugSmpB16.py
@@ -1,6 +1,8 @@
 import binascii
 from bluepy import btle
 
+START_OF_MESSAGE = bytes([0x0f])
+END_OF_MESSAGE = bytes([0xff, 0xff])
 
 class SmartPlug(btle.Peripheral):
     def __init__(self, addr):
@@ -12,21 +14,31 @@ class SmartPlug(btle.Peripheral):
 
     def on(self):
         self.delegate.chg_is_ok = False
-        self.plug_cmd_ch.write(binascii.unhexlify('0f06030001000005ffff'))
-        self.waitForNotifications(0.5)
+        self.plug_cmd_ch.write(self.get_buffer(binascii.unhexlify('0300010000')))
+        self.wait_data(0.5)
         return self.delegate.chg_is_ok
 
     def off(self):
         self.delegate.chg_is_ok = False
-        self.plug_cmd_ch.write(binascii.unhexlify('0f06030000000004ffff'))
-        self.waitForNotifications(0.5)
+        self.plug_cmd_ch.write(self.get_buffer(binascii.unhexlify('0300000000')))
+        self.wait_data(0.5)
         return self.delegate.chg_is_ok
 
     def status_request(self):
-        self.plug_cmd_ch.write(binascii.unhexlify('0f050400000005ffff'))
-        self.waitForNotifications(2.0)
+        self.plug_cmd_ch.write(self.get_buffer(binascii.unhexlify('04000000')))
+        self.wait_data(2.0)
         return self.delegate.state, self.delegate.power
 
+    def calculate_checksum(self, message):
+        return ((sum(message) + 1) & 0xff).to_bytes(1, byteorder='big')
+
+    def get_buffer(self, message):
+        return START_OF_MESSAGE + (len(message) + 1).to_bytes(1,byteorder='big') + message +  self.calculate_checksum(message) + END_OF_MESSAGE 
+
+    def wait_data(self, timeout):
+        self.delegate.need_data = True
+        while self.delegate.need_data and self.waitForNotifications(timeout):
+            pass
 
 class NotificationDelegate(btle.DefaultDelegate):
     def __init__(self):
@@ -34,16 +46,32 @@ class NotificationDelegate(btle.DefaultDelegate):
         self.state = False
         self.power = 0
         self.chg_is_ok = False
+        self._buffer = b''
+        self.need_data = True
 
     def handleNotification(self, cHandle, data):
-        bytes_data = bytearray(data)
+        #not sure 0x0f indicate begin of buffer but
+        if data[:1] == START_OF_MESSAGE:
+            self._buffer = data
+        else:
+            self._buffer = self._buffer + data
+        if self._buffer[-2:] == END_OF_MESSAGE:
+            self.handle_data(self._buffer)
+            self._buffer = b''
+            self.need_data = False 
+
+    def handle_data(self, bytes_data):
         # it's a state change confirm notification ?
-        if bytes_data[0:3] == bytearray([0x0f, 0x04, 0x03]):
+        if bytes_data[0:3] == bytes([0x0f, 0x04, 0x03]):
             self.chg_is_ok = True
         # it's a state/power notification ?
-        if bytes_data[0:3] == bytearray([0x0f, 0x0f, 0x04]):
+        if bytes_data[0:3] == bytes([0x0f, 0x0f, 0x04]):
             self.state = bytes_data[4] == 1
             self.power = int(binascii.hexlify(bytes_data[6:10]), 16) / 1000
+        # it's a 0x0a notif ?
+        if bytes_data[0:3] == bytes([0x0f, 0x33, 0x0a]):
+            print ("0A notif %s" % bytes_data)
+
 
 
 # SmartPlugSmpB16 usage sample: cycle power then log plug state and power level to terminal

--- a/pySmartPlugSmpB16.py
+++ b/pySmartPlugSmpB16.py
@@ -1,4 +1,5 @@
 import binascii
+import struct
 from bluepy import btle
 
 START_OF_MESSAGE = bytes([0x0f])
@@ -66,8 +67,9 @@ class NotificationDelegate(btle.DefaultDelegate):
             self.chg_is_ok = True
         # it's a state/power notification ?
         if bytes_data[0:3] == bytes([0x0f, 0x0f, 0x04]):
-            self.state = bytes_data[4] == 1
-            self.power = int(binascii.hexlify(bytes_data[6:10]), 16) / 1000
+            (state,dummy,power) = struct.unpack_from(">?hi",bytes_data,4)
+            self.state = state
+            self.power = power / 1000
         # it's a 0x0a notif ?
         if bytes_data[0:3] == bytes([0x0f, 0x33, 0x0a]):
             print ("0A notif %s" % bytes_data)

--- a/pySmartPlugSmpB16.py
+++ b/pySmartPlugSmpB16.py
@@ -83,11 +83,11 @@ class NotificationDelegate(btle.DefaultDelegate):
         if bytes_data[0:3] == bytes([0x0f, 0x71, 0x07]):
             program_offset = 4
             self.programs = []
-            while program_offset < len(bytes_data):
-                (present, name, flags, start_hour, start_minute, end_hour, end_minute) = struct.unpack_from(">?16sccccc", bytes_data, program_offset)
+            while program_offset + 21 < len(bytes_data):
+                (present, name, flags, start_hour, start_minute, end_hour, end_minute) = struct.unpack_from(">?16sbbbbb", bytes_data, program_offset)
                 #TODO interpret flags (day of program ?)
                 if present:
-                    self.programs.append({ "name" : name, "flags":flags, "start":"{}:{}".format(start_hour, start_minute), "end":"{}:{}".format(end_hour, end_minute)})
+                    self.programs.append({ "name" : name.decode('iso-8859-1').strip('\0'), "flags":flags, "start":"{0:02d}:{1:02d}".format(start_hour, start_minute), "end":"{0:02d}:{1:02d}".format(end_hour, end_minute)})
                 program_offset += 22
 
 # SmartPlugSmpB16 usage sample: cycle power then log plug state and power level to terminal

--- a/scripts/smartplugctl
+++ b/scripts/smartplugctl
@@ -19,7 +19,7 @@ from pySmartPlugSmpB16 import SmartPlug, btle
 parser = argparse.ArgumentParser()
 parser.add_argument('ble_addr', type=str, 
                     help='plug bluetooth LE address (like 98:7b:f3:34:78:52)')
-parser.add_argument('command', type=str, choices=['on', 'off', 'status', 'program'],
+parser.add_argument('command', type=str, choices=['on', 'off', 'status', 'read_programs'],
                     help='command to send at plug')
 args = parser.parse_args()
 
@@ -57,7 +57,7 @@ elif args.command == 'status':
     status = 'on' if state else 'off'
     print('plug state = %s' % status)
     print('plug power = %d W' % power)
-elif args.command == 'program':
+elif args.command == 'read_programs':
     try:
         (programs) = plug.program_request()
     except btle.BTLEException as err:

--- a/scripts/smartplugctl
+++ b/scripts/smartplugctl
@@ -12,13 +12,14 @@
 from __future__ import print_function
 import sys
 import argparse
+import pprint
 from pySmartPlugSmpB16 import SmartPlug, btle
 
 # parse args
 parser = argparse.ArgumentParser()
 parser.add_argument('ble_addr', type=str, 
                     help='plug bluetooth LE address (like 98:7b:f3:34:78:52)')
-parser.add_argument('command', type=str, choices=['on', 'off', 'status'],
+parser.add_argument('command', type=str, choices=['on', 'off', 'status', 'program'],
                     help='command to send at plug')
 args = parser.parse_args()
 
@@ -56,6 +57,14 @@ elif args.command == 'status':
     status = 'on' if state else 'off'
     print('plug state = %s' % status)
     print('plug power = %d W' % power)
+elif args.command == 'program':
+    try:
+        (programs) = plug.program_request()
+    except btle.BTLEException as err:
+        sys.exit('error when requesting stat to plug %s (code %d)' % (args.ble_addr, err.code))
+    # print result
+    print('plug programs : ' )
+    pprint.pprint(programs)
 
 # disconnect BLE
 plug.disconnect()


### PR DESCRIPTION
J'ai ajouté la lecture des programmes "calendrier" de la prise.
Il a fallu un peu changé la méthode de réception pour lire les messages réparties sur plusieurs notifications.

J'ai découvert en faisant que tous les messages ont la forme suivante :

0F indicateur de début
XX longueur jusqu'au checksum inclus
CC Commande
00 
DD données 
DD
DD
CK Checksum (somme des octets + 1)
FF indicateur de fin 
FF 

